### PR TITLE
use builtin sorting for composed dependencies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,9 +41,10 @@ module.exports = postcss.plugin('postcss-modules', (opts = {}) => {
       postcss([...plugins, parser.plugin])
         .process(css, { from: css.source.input.file })
         .then(() => {
-          Object.keys(loader.sources).forEach(key => {
-            css.prepend(loader.sources[key]);
-          });
+          const out = loader.finalSource;
+          if (out) {
+            css.prepend(out);
+          }
 
           getJSON(css.source.input.file, parser.exportTokens);
 

--- a/test/fixtures/out/composes.css
+++ b/test/fixtures/out/composes.css
@@ -1,3 +1,15 @@
+._composes_a_another-mixin {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    height: 100px;
+    width: 200px;
+}
+
+._composes_a_hello {
+    foo: bar;
+}
+
 ._composes_mixins_title {
     color: black;
     font-size: 40px;
@@ -14,18 +26,6 @@
 ._composes_mixins_title:focus, ._composes_mixins_figure:focus {
     outline: none;
     border: 1px solid red;
-}
-
-._composes_a_another-mixin {
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    height: 100px;
-    width: 200px;
-}
-
-._composes_a_hello {
-    foo: bar;
 }
 
 .page {


### PR DESCRIPTION
Fixes #38 

`loader.finalSource` gives all of the composed sources, but sorted in order of dependency: https://github.com/css-modules/css-modules-loader-core/blob/master/src/file-system-loader.js#L63

This ensures that when you compose classes you can still override rules as expected.