### PR TITLE
Bumping version of css-modules-loader-core to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/css-modules/postcss-modules.git"
   },
   "dependencies": {
-    "css-modules-loader-core": "^1.0.0",
+    "css-modules-loader-core": "^1.0.1",
     "generic-names": "^1.0.1",
     "postcss": "^5.0.21",
     "string-hash": "^1.1.0"


### PR DESCRIPTION
There was a bug css-modules-loader-core that was fixed today. New version is released. This just bumps that up.