### PR TITLE
Add `root` opt

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,9 +31,10 @@ function getScopedNameGenerator(opts) {
 
 
 function getLoader(opts, plugins) {
+  const root = opts.root || '/';
   return typeof opts.Loader === 'function'
-    ? new opts.Loader('/', plugins)
-    : new FileSystemLoader('/', plugins);
+    ? new opts.Loader(root, plugins)
+    : new FileSystemLoader(root, plugins);
 }
 
 


### PR DESCRIPTION
On windows, I get paths that look like this: `C:/C:/path/to/file`. This is because that default `'/'` is appended to the path and sent to `path.resolve` later.