### PR TITLE
allow async getJSON (& adapt saveJSON)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ postcss([
 ]);
 ```
 
+`getJSON` may also return a `Promise`.
+
 ### Generating scoped names
 
 By default, the plugin assumes that all the classes are local. You can change

--- a/src/index.js
+++ b/src/index.js
@@ -72,17 +72,14 @@ module.exports = postcss.plugin(PLUGIN_NAME, (opts = {}) => {
     const loader        = getLoader(opts, plugins);
     const parser        = new Parser(loader.fetch.bind(loader));
 
-    return new Promise((resolve, reject) => {
-      postcss([...plugins, parser.plugin])
-        .process(css, { from: inputFile })
-        .then(() => {
-          const out = loader.finalSource;
-          if (out) css.prepend(out);
+    return postcss([...plugins, parser.plugin])
+      .process(css, { from: inputFile })
+      .then(() => {
+        const out = loader.finalSource;
+        if (out) css.prepend(out);
 
-          getJSON(css.source.input.file, parser.exportTokens);
-
-          resolve();
-        }, reject);
-    });
+        // getJSON may return a thenable
+        return getJSON(css.source.input.file, parser.exportTokens);
+      });
   };
 });

--- a/src/saveJSON.js
+++ b/src/saveJSON.js
@@ -1,5 +1,10 @@
-import { writeFileSync } from 'fs';
+import { writeFile } from 'fs';
 
 export default function saveJSON(cssFile, json) {
-  writeFileSync(`${ cssFile }.json`, JSON.stringify(json));
+  return new Promise((resolve, reject) => {
+    writeFile(
+      `${ cssFile }.json`,
+      JSON.stringify(json),
+      e => (e ? reject(e) : resolve(json)));
+  });
 }


### PR DESCRIPTION
why not go the whole way with promises?

this way we don’t force people (e.g. me 😛) to use sync variants of IO functions.