### PR TITLE
Add ability to transmit outputFileName into getJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ use the `getJSON` callback. For example, save data about classes into a correspo
 ```js
 postcss([
   require('postcss-modules')({
-    getJSON: function(cssFileName, json) {
+    getJSON: function(cssFileName, json, outputFileName) {
       var path          = require('path');
       var cssName       = path.basename(cssFileName, '.css');
       var jsonFileName  = path.resolve('./build/' + cssName + '.json');

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,6 @@ module.exports = postcss.plugin(PLUGIN_NAME, (opts = {}) => {
     if (out) css.prepend(out);
 
     // getJSON may return a promise
-    return getJSON(css.source.input.file, parser.exportTokens);
+    return getJSON(css.source.input.file, parser.exportTokens, result.opts.to);
   };
 });

--- a/test/fixtures/in/test/getJSON.css
+++ b/test/fixtures/in/test/getJSON.css
@@ -1,0 +1,3 @@
+.link {
+    color: green;
+}

--- a/test/fixtures/out/test/getJSON.css
+++ b/test/fixtures/out/test/getJSON.css
@@ -1,0 +1,3 @@
+._getJSON_link {
+  color: green;
+}

--- a/test/fixtures/out/test/getJSON.json
+++ b/test/fixtures/out/test/getJSON.json
@@ -1,0 +1,3 @@
+{
+  "link": "_getJSON_link"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -120,3 +120,27 @@ test('different instances have different generateScopedName functions', async (t
   t.is(resultTwo.css, '.two {}');
   t.not(resultOne.css, resultTwo.css);
 });
+
+test('getJSON with outputFileName', async (t) => {
+  const sourceFile   = path.join(fixturesPath, 'in', 'test', 'getJSON.css');
+  const expectedFile = path.join(fixturesPath, 'out', 'test', 'getJSON');
+  const source       = fs.readFileSync(sourceFile).toString();
+  const expectedJSON = fs.readFileSync(`${ expectedFile }.json`).toString();
+  let jsonFileName;
+  let resultJson;
+
+  const plugins = [
+    plugin({
+      generateScopedName,
+      getJSON: (cssFile, json, outputFileName) => {
+        jsonFileName = outputFileName.replace('.css', '.json');
+        resultJson = json;
+      },
+    }),
+  ];
+
+  await postcss(plugins).process(source, { from: sourceFile, to: `${ expectedFile }.css` });
+
+  t.deepEqual(jsonFileName, `${ expectedFile }.json`);
+  t.deepEqual(resultJson, JSON.parse(expectedJSON));
+});


### PR DESCRIPTION
In `postcss-cli` now there is an ability to keep folder structure that's why placement of built files can be a bit unpredictable. But still, it would be nice for some cases to keep json files with built files together. So, here is my proposal to provide output file name into `getJSON` method to give ability use it in generation paths for json files