### PR TITLE
"support different exported types (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,26 +181,19 @@ postcss([
 ]);
 ```
 
-### Camel cased classes
+### localsConvention
 
-If you need, you can pass the options `{ camelCase: true }` to transform classes:
+Type: `String`
+Default: `null`
 
-CSS:
+Style of exported classnames.
 
-```css
-.post-title {
-  color: red;
-}
-```
-
-JSON:
-
-```json
-{
-  "post-title": "._post-title_116zl_1",
-  "postTitle": "._post-title_116zl_1"
-}
-```
+|         Name          |    Type    | Description                                                                                      |
+| :-------------------: | :--------: | :----------------------------------------------------------------------------------------------- |
+|   **`'camelCase'`**   | `{String}` | Class names will be camelized, the original class name will not to be removed from the locals    |
+| **`'camelCaseOnly'`** | `{String}` | Class names will be camelized, the original class name will be removed from the locals           |
+|    **`'dashes'`**     | `{String}` | Only dashes in class names will be camelized                                                     |
+|  **`'dashesOnly'`**   | `{String}` | Dashes in class names will be camelized, the original class name will be removed from the locals |
 
 ## Integration with templates
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-modules",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "PostCSS plugin to use CSS Modules everywhere",
   "main": "build/index.js",
   "keywords": [

--- a/test/fixtures/in/camelCase.css
+++ b/test/fixtures/in/camelCase.css
@@ -1,3 +1,11 @@
 .camel-case {
     background: red;
 }
+
+.camel-case-extra {
+    background: blue;
+}
+
+.FooBar {
+    background: green;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -91,24 +91,92 @@ it("processes globalModulePaths option", async () => {
   expect(result.css).toMatchSnapshot("processes globalModulePaths option");
 });
 
-it("processes camelCase option", async () => {
+it("processes localsConvention with camelCase option", async () => {
   const sourceFile = path.join(fixturesPath, "in", "camelCase.css");
   const source = fs.readFileSync(sourceFile).toString();
   const jsonFile = path.join(fixturesPath, "in", "camelCase.css.json");
 
   if (fs.existsSync(jsonFile)) fs.unlinkSync(jsonFile);
 
-  await postcss([plugin({ generateScopedName, camelCase: true })]).process(
-    source,
-    { from: sourceFile }
-  );
+  await postcss([
+    plugin({ generateScopedName, localsConvention: "camelCase" })
+  ]).process(source, { from: sourceFile });
+
+  const json = fs.readFileSync(jsonFile).toString();
+  fs.unlinkSync(jsonFile);
+
+  expect(JSON.parse(json)).toMatchObject({
+    "camel-case": "_camelCase_camel-case",
+    camelCase: "_camelCase_camel-case",
+    "camel-case-extra": "_camelCase_camel-case-extra",
+    camelCaseExtra: "_camelCase_camel-case-extra",
+    FooBar: "_camelCase_FooBar",
+    fooBar: "_camelCase_FooBar"
+  });
+});
+
+it("processes localsConvention with camelCaseOnly option", async () => {
+  const sourceFile = path.join(fixturesPath, "in", "camelCase.css");
+  const source = fs.readFileSync(sourceFile).toString();
+  const jsonFile = path.join(fixturesPath, "in", "camelCase.css.json");
+
+  if (fs.existsSync(jsonFile)) fs.unlinkSync(jsonFile);
+
+  await postcss([
+    plugin({ generateScopedName, localsConvention: "camelCaseOnly" })
+  ]).process(source, { from: sourceFile });
 
   const json = fs.readFileSync(jsonFile).toString();
   fs.unlinkSync(jsonFile);
 
   expect(JSON.parse(json)).toMatchObject({
     camelCase: "_camelCase_camel-case",
-    "camel-case": "_camelCase_camel-case"
+    camelCaseExtra: "_camelCase_camel-case-extra",
+    fooBar: "_camelCase_FooBar"
+  });
+});
+
+it("processes localsConvention with dashes option", async () => {
+  const sourceFile = path.join(fixturesPath, "in", "camelCase.css");
+  const source = fs.readFileSync(sourceFile).toString();
+  const jsonFile = path.join(fixturesPath, "in", "camelCase.css.json");
+
+  if (fs.existsSync(jsonFile)) fs.unlinkSync(jsonFile);
+
+  await postcss([
+    plugin({ generateScopedName, localsConvention: "dashes" })
+  ]).process(source, { from: sourceFile });
+
+  const json = fs.readFileSync(jsonFile).toString();
+  fs.unlinkSync(jsonFile);
+
+  expect(JSON.parse(json)).toMatchObject({
+    "camel-case": "_camelCase_camel-case",
+    camelCase: "_camelCase_camel-case",
+    "camel-case-extra": "_camelCase_camel-case-extra",
+    camelCaseExtra: "_camelCase_camel-case-extra",
+    FooBar: "_camelCase_FooBar"
+  });
+});
+
+it("processes localsConvention with dashes option", async () => {
+  const sourceFile = path.join(fixturesPath, "in", "camelCase.css");
+  const source = fs.readFileSync(sourceFile).toString();
+  const jsonFile = path.join(fixturesPath, "in", "camelCase.css.json");
+
+  if (fs.existsSync(jsonFile)) fs.unlinkSync(jsonFile);
+
+  await postcss([
+    plugin({ generateScopedName, localsConvention: "dashes" })
+  ]).process(source, { from: sourceFile });
+
+  const json = fs.readFileSync(jsonFile).toString();
+  fs.unlinkSync(jsonFile);
+
+  expect(JSON.parse(json)).toMatchObject({
+    camelCase: "_camelCase_camel-case",
+    camelCaseExtra: "_camelCase_camel-case-extra",
+    FooBar: "_camelCase_FooBar"
   });
 });
 


### PR DESCRIPTION
Now is supports _camelCase, camelCaseOnly, dashes and dashesOnly_ as well. Instead of the property **camelCase**, there is a new property called **localsConvention** which takes as value one of those 4 values above.
Tests have been added for those options as well and ran successfully.

Please make sure to update the package from NPM too, as I really need this ASAP on one of my projects, being urgent.