### PR TITLE
only apply user plugins to loader

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,14 +77,7 @@ module.exports = postcss.plugin(PLUGIN_NAME, (opts = {}) => {
   return async (css, result) => {
     const inputFile = css.source.input.file;
     const pluginList = getDefaultPluginsList(opts, inputFile);
-    let resultPluginIndex;
-    result.processor.plugins.some((plugin, i) => {
-      if (isOurPlugin(plugin)) {
-        resultPluginIndex = i;
-        return true;
-      }
-      return false;
-    });
+    const resultPluginIndex = result.processor.plugins.findIndex((plugin) => isOurPlugin(plugin));
     if (resultPluginIndex === undefined) {
       throw new Error('Plugin missing from options.');
     }

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ module.exports = postcss.plugin(PLUGIN_NAME, (opts = {}) => {
     const inputFile = css.source.input.file;
     const pluginList = getDefaultPluginsList(opts, inputFile);
     const resultPluginIndex = result.processor.plugins.findIndex((plugin) => isOurPlugin(plugin));
-    if (resultPluginIndex === undefined) {
+    if (resultPluginIndex === -1) {
       throw new Error('Plugin missing from options.');
     }
     const earlierPlugins = result.processor.plugins.slice(0, resultPluginIndex);

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`allows to make CSS global: allows to make CSS global - CSS 1`] = `
-"/* this should appear once in each file */
+"/* validator-2 */
 
-/* this should also appear once in each file */
+/* validator-1 */
 
 .page {
     padding: 20px;
@@ -22,7 +22,7 @@ Object {
 `;
 
 exports[`composes rules: composes rules - CSS 1`] = `
-"/* this should appear once in each file *//* this should also appear once in each file */._composes_a_another-mixin {
+"/* validator-2 *//* validator-1 */._composes_a_another-mixin {
     display: -webkit-flex;
     display: -moz-box;
     display: flex;
@@ -30,7 +30,7 @@ exports[`composes rules: composes rules - CSS 1`] = `
     width: 200px;
 }._composes_a_hello {
     foo: bar;
-}/* this should also appear once in each file */._composes_mixins_title {
+}/* validator-1 */._composes_mixins_title {
     color: black;
     font-size: 40px;
 }._composes_mixins_title:hover {
@@ -42,7 +42,7 @@ exports[`composes rules: composes rules - CSS 1`] = `
     border: 1px solid red;
 }
 
-/* this should also appear once in each file */
+/* validator-1 */
 
 .page {
     padding: 20px;
@@ -89,9 +89,9 @@ Array [
 `;
 
 exports[`generates scoped name with interpolated string: generates scoped name with interpolated string - CSS 1`] = `
-"/* this should appear once in each file */
+"/* validator-2 */
 
-/* this should also appear once in each file */
+/* validator-1 */
 
 .interpolated__title___2P3iB {
     color: green;
@@ -111,8 +111,8 @@ Object {
 `;
 
 exports[`preserves comments: preserves comments - CSS 1`] = `
-"/* this should appear once in each file */
-/* this should also appear once in each file */
+"/* validator-2 */
+/* validator-1 */
 /**
  * This is a doc comment...
  */
@@ -126,9 +126,9 @@ p {
 exports[`preserves comments: preserves comments - JSON 1`] = `Object {}`;
 
 exports[`processes classes: processes classes - CSS 1`] = `
-"/* this should appear once in each file */
+"/* validator-2 */
 
-/* this should also appear once in each file */
+/* validator-1 */
 
 .page {
     padding: 20px;
@@ -165,11 +165,11 @@ exports[`processes globalModulePaths option: processes globalModulePaths option 
 exports[`processes hashPrefix option: processes hashPrefix option 1`] = `"._8xPWf {}"`;
 
 exports[`processes values: processes values - CSS 1`] = `
-"/* this should appear once in each file */
+"/* validator-2 */
 
-/* this should also appear once in each file */
+/* validator-1 */
 
-/* this should also appear once in each file */
+/* validator-1 */
 
 ._values_title {
     color: green;
@@ -192,7 +192,7 @@ Object {
 `;
 
 exports[`saves origin plugins: saves origin plugins - CSS 1`] = `
-"/* this should appear once in each file *//* this should also appear once in each file */
+"/* validator-2 *//* validator-1 */
 ._plugins_title {
     display: -webkit-flex;
     display: -moz-box;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,6 +1,106 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`allows to make CSS global: allows to make CSS global - CSS 1`] = `
+".page {
+    padding: 20px;
+}
+
+._global_title {
+    color: green;
+}
+"
+`;
+
+exports[`allows to make CSS global: allows to make CSS global - JSON 1`] = `
+Object {
+  "title": "_global_title",
+}
+`;
+
+exports[`composes rules: composes rules - CSS 1`] = `
+"._composes_a_another-mixin {
+    display: -webkit-flex;
+    display: -moz-box;
+    display: flex;
+    height: 100px;
+    width: 200px;
+}._composes_a_hello {
+    foo: bar;
+}._composes_mixins_title {
+    color: black;
+    font-size: 40px;
+}._composes_mixins_title:hover {
+    color: red;
+}._composes_mixins_figure {
+    text-align: center
+}._composes_mixins_title:focus, ._composes_mixins_figure:focus {
+    outline: none;
+    border: 1px solid red;
+}
+
+.page {
+    padding: 20px;
+}
+
+._composes_title {
+    color: green;
+}
+
+._composes_article {
+    font-size: 16px;
+}
+
+._composes_figure {
+    display: -webkit-flex;
+    display: -moz-box;
+    display: flex;
+}
+"
+`;
+
+exports[`composes rules: composes rules - JSON 1`] = `
+Object {
+  "article": "_composes_article",
+  "figure": "_composes_figure _composes_mixins_figure _composes_a_another-mixin",
+  "title": "_composes_title _composes_mixins_title",
+}
+`;
+
+exports[`exposes export tokens for other plugins: exposes export tokens for other plugins 1`] = `
+Array [
+  Object {
+    "exportTokens": Object {
+      "article": "_values_article",
+      "colors": "\\"./values.colors.css\\"",
+      "primary": "green",
+      "secondary": "blue",
+      "title": "_values_title",
+    },
+    "plugin": "postcss-modules",
+    "type": "export",
+  },
+]
+`;
+
+exports[`generates scoped name with interpolated string: generates scoped name with interpolated string - CSS 1`] = `
+".interpolated__title___2P3iB {
+    color: green;
+}
+
+.interpolated__article___Skl0x {
+    color: black;
+}
+"
+`;
+
+exports[`generates scoped name with interpolated string: generates scoped name with interpolated string - JSON 1`] = `
+Object {
+  "article": "interpolated__article___Skl0x",
+  "title": "interpolated__title___2P3iB",
+}
+`;
+
+exports[`only calls plugins once when it allows to make CSS global: plugins once - allows to make CSS global - CSS 1`] = `
 "/* validator-2-start (global.css) */
 
 /* validator-1-start (global.css) */
@@ -19,13 +119,7 @@ exports[`allows to make CSS global: allows to make CSS global - CSS 1`] = `
 "
 `;
 
-exports[`allows to make CSS global: allows to make CSS global - JSON 1`] = `
-Object {
-  "title": "_global_title",
-}
-`;
-
-exports[`composes rules: composes rules - CSS 1`] = `
+exports[`only calls plugins once when it composes rules: plugins once - composes rules - CSS 1`] = `
 "/* validator-2-start (composes.css) *//* validator-1-start (composes.a.css) */._composes_a_another-mixin {
     display: -webkit-flex;
     display: -moz-box;
@@ -72,31 +166,7 @@ exports[`composes rules: composes rules - CSS 1`] = `
 "
 `;
 
-exports[`composes rules: composes rules - JSON 1`] = `
-Object {
-  "article": "_composes_article",
-  "figure": "_composes_figure _composes_mixins_figure _composes_a_another-mixin",
-  "title": "_composes_title _composes_mixins_title",
-}
-`;
-
-exports[`exposes export tokens for other plugins: exposes export tokens for other plugins 1`] = `
-Array [
-  Object {
-    "exportTokens": Object {
-      "article": "_values_article",
-      "colors": "\\"./values.colors.css\\"",
-      "primary": "green",
-      "secondary": "blue",
-      "title": "_values_title",
-    },
-    "plugin": "postcss-modules",
-    "type": "export",
-  },
-]
-`;
-
-exports[`generates scoped name with interpolated string: generates scoped name with interpolated string - CSS 1`] = `
+exports[`only calls plugins once when it generates scoped name with interpolated string: plugins once - generates scoped name with interpolated string - CSS 1`] = `
 "/* validator-2-start (interpolated.css) */
 
 /* validator-1-start (interpolated.css) */
@@ -115,14 +185,7 @@ exports[`generates scoped name with interpolated string: generates scoped name w
 "
 `;
 
-exports[`generates scoped name with interpolated string: generates scoped name with interpolated string - JSON 1`] = `
-Object {
-  "article": "interpolated__article___Skl0x",
-  "title": "interpolated__title___2P3iB",
-}
-`;
-
-exports[`preserves comments: preserves comments - CSS 1`] = `
+exports[`only calls plugins once when it preserves comments: plugins once - preserves comments - CSS 1`] = `
 "/* validator-2-start (comments.css) */
 /* validator-1-start (comments.css) */
 /**
@@ -137,9 +200,7 @@ p {
 "
 `;
 
-exports[`preserves comments: preserves comments - JSON 1`] = `Object {}`;
-
-exports[`processes classes: processes classes - CSS 1`] = `
+exports[`only calls plugins once when it processes classes: plugins once - processes classes - CSS 1`] = `
 "/* validator-2-start (classes.css) */
 
 /* validator-1-start (classes.css) */
@@ -159,6 +220,64 @@ exports[`processes classes: processes classes - CSS 1`] = `
 /* validator-1-end (classes.css) */
 
 /* validator-2-end (classes.css) */
+"
+`;
+
+exports[`only calls plugins once when it processes values: plugins once - processes values - CSS 1`] = `
+"/* validator-2-start (values.css) *//* validator-1-start (values.colors.css) *//* validator-1-end (values.colors.css) */
+
+/* validator-1-start (values.css) */
+
+._values_title {
+    color: green;
+}
+
+._values_article {
+    color: blue;
+}
+
+/* validator-1-end (values.css) */
+
+/* validator-2-end (values.css) */
+"
+`;
+
+exports[`only calls plugins once when it saves origin plugins: plugins once - saves origin plugins - CSS 1`] = `
+"/* validator-2-start (plugins.css) *//* validator-1-start (plugins.css) */
+._plugins_title {
+    display: -webkit-flex;
+    display: -moz-box;
+    display: flex;
+    color: green;
+}/* validator-1-end (plugins.css) *//* validator-2-end (plugins.css) */
+"
+`;
+
+exports[`preserves comments: preserves comments - CSS 1`] = `
+"/**
+ * This is a doc comment...
+ */
+p {
+  /* ...and a line comment */
+  padding: 0;
+}
+"
+`;
+
+exports[`preserves comments: preserves comments - JSON 1`] = `Object {}`;
+
+exports[`processes classes: processes classes - CSS 1`] = `
+".page {
+    padding: 20px;
+}
+
+._classes_title {
+    color: green;
+}
+
+._classes_article {
+    color: black;
+}
 "
 `;
 
@@ -183,9 +302,7 @@ exports[`processes globalModulePaths option: processes globalModulePaths option 
 exports[`processes hashPrefix option: processes hashPrefix option 1`] = `"._8xPWf {}"`;
 
 exports[`processes values: processes values - CSS 1`] = `
-"/* validator-2-start (values.css) *//* validator-1-start (values.colors.css) *//* validator-1-end (values.colors.css) */
-
-/* validator-1-start (values.css) */
+"
 
 ._values_title {
     color: green;
@@ -194,10 +311,6 @@ exports[`processes values: processes values - CSS 1`] = `
 ._values_article {
     color: blue;
 }
-
-/* validator-1-end (values.css) */
-
-/* validator-2-end (values.css) */
 "
 `;
 
@@ -212,13 +325,12 @@ Object {
 `;
 
 exports[`saves origin plugins: saves origin plugins - CSS 1`] = `
-"/* validator-2-start (plugins.css) *//* validator-1-start (plugins.css) */
-._plugins_title {
+"._plugins_title {
     display: -webkit-flex;
     display: -moz-box;
     display: flex;
     color: green;
-}/* validator-1-end (plugins.css) *//* validator-2-end (plugins.css) */
+}
 "
 `;
 

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`allows to make CSS global: allows to make CSS global - CSS 1`] = `
-"/* validator-2 */
+"/* validator-2 (global.css) */
 
-/* validator-1 */
+/* validator-1 (global.css) */
 
 .page {
     padding: 20px;
@@ -22,7 +22,7 @@ Object {
 `;
 
 exports[`composes rules: composes rules - CSS 1`] = `
-"/* validator-2 *//* validator-1 */._composes_a_another-mixin {
+"/* validator-2 (composes.css) *//* validator-1 (composes.a.css) */._composes_a_another-mixin {
     display: -webkit-flex;
     display: -moz-box;
     display: flex;
@@ -30,7 +30,7 @@ exports[`composes rules: composes rules - CSS 1`] = `
     width: 200px;
 }._composes_a_hello {
     foo: bar;
-}/* validator-1 */._composes_mixins_title {
+}/* validator-1 (composes.mixins.css) */._composes_mixins_title {
     color: black;
     font-size: 40px;
 }._composes_mixins_title:hover {
@@ -42,7 +42,7 @@ exports[`composes rules: composes rules - CSS 1`] = `
     border: 1px solid red;
 }
 
-/* validator-1 */
+/* validator-1 (composes.css) */
 
 .page {
     padding: 20px;
@@ -89,9 +89,9 @@ Array [
 `;
 
 exports[`generates scoped name with interpolated string: generates scoped name with interpolated string - CSS 1`] = `
-"/* validator-2 */
+"/* validator-2 (interpolated.css) */
 
-/* validator-1 */
+/* validator-1 (interpolated.css) */
 
 .interpolated__title___2P3iB {
     color: green;
@@ -111,8 +111,8 @@ Object {
 `;
 
 exports[`preserves comments: preserves comments - CSS 1`] = `
-"/* validator-2 */
-/* validator-1 */
+"/* validator-2 (comments.css) */
+/* validator-1 (comments.css) */
 /**
  * This is a doc comment...
  */
@@ -126,9 +126,9 @@ p {
 exports[`preserves comments: preserves comments - JSON 1`] = `Object {}`;
 
 exports[`processes classes: processes classes - CSS 1`] = `
-"/* validator-2 */
+"/* validator-2 (classes.css) */
 
-/* validator-1 */
+/* validator-1 (classes.css) */
 
 .page {
     padding: 20px;
@@ -165,11 +165,11 @@ exports[`processes globalModulePaths option: processes globalModulePaths option 
 exports[`processes hashPrefix option: processes hashPrefix option 1`] = `"._8xPWf {}"`;
 
 exports[`processes values: processes values - CSS 1`] = `
-"/* validator-2 */
+"/* validator-2 (values.css) */
 
-/* validator-1 */
+/* validator-1 (values.colors.css) */
 
-/* validator-1 */
+/* validator-1 (values.css) */
 
 ._values_title {
     color: green;
@@ -192,7 +192,7 @@ Object {
 `;
 
 exports[`saves origin plugins: saves origin plugins - CSS 1`] = `
-"/* validator-2 *//* validator-1 */
+"/* validator-2 (plugins.css) *//* validator-1 (plugins.css) */
 ._plugins_title {
     display: -webkit-flex;
     display: -moz-box;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`allows to make CSS global: allows to make CSS global - CSS 1`] = `
-".page {
+"/* this should appear once in each file */
+
+/* this should also appear once in each file */
+
+.page {
     padding: 20px;
 }
 
@@ -18,7 +22,7 @@ Object {
 `;
 
 exports[`composes rules: composes rules - CSS 1`] = `
-"._composes_a_another-mixin {
+"/* this should appear once in each file *//* this should also appear once in each file */._composes_a_another-mixin {
     display: -webkit-flex;
     display: -moz-box;
     display: flex;
@@ -26,7 +30,7 @@ exports[`composes rules: composes rules - CSS 1`] = `
     width: 200px;
 }._composes_a_hello {
     foo: bar;
-}._composes_mixins_title {
+}/* this should also appear once in each file */._composes_mixins_title {
     color: black;
     font-size: 40px;
 }._composes_mixins_title:hover {
@@ -37,6 +41,8 @@ exports[`composes rules: composes rules - CSS 1`] = `
     outline: none;
     border: 1px solid red;
 }
+
+/* this should also appear once in each file */
 
 .page {
     padding: 20px;
@@ -83,7 +89,11 @@ Array [
 `;
 
 exports[`generates scoped name with interpolated string: generates scoped name with interpolated string - CSS 1`] = `
-".interpolated__title___2P3iB {
+"/* this should appear once in each file */
+
+/* this should also appear once in each file */
+
+.interpolated__title___2P3iB {
     color: green;
 }
 
@@ -101,7 +111,9 @@ Object {
 `;
 
 exports[`preserves comments: preserves comments - CSS 1`] = `
-"/**
+"/* this should appear once in each file */
+/* this should also appear once in each file */
+/**
  * This is a doc comment...
  */
 p {
@@ -114,7 +126,11 @@ p {
 exports[`preserves comments: preserves comments - JSON 1`] = `Object {}`;
 
 exports[`processes classes: processes classes - CSS 1`] = `
-".page {
+"/* this should appear once in each file */
+
+/* this should also appear once in each file */
+
+.page {
     padding: 20px;
 }
 
@@ -149,7 +165,11 @@ exports[`processes globalModulePaths option: processes globalModulePaths option 
 exports[`processes hashPrefix option: processes hashPrefix option 1`] = `"._8xPWf {}"`;
 
 exports[`processes values: processes values - CSS 1`] = `
-"
+"/* this should appear once in each file */
+
+/* this should also appear once in each file */
+
+/* this should also appear once in each file */
 
 ._values_title {
     color: green;
@@ -172,7 +192,8 @@ Object {
 `;
 
 exports[`saves origin plugins: saves origin plugins - CSS 1`] = `
-"._plugins_title {
+"/* this should appear once in each file *//* this should also appear once in each file */
+._plugins_title {
     display: -webkit-flex;
     display: -moz-box;
     display: flex;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`allows to make CSS global: allows to make CSS global - CSS 1`] = `
-"/* validator-2 (global.css) */
+"/* validator-2-start (global.css) */
 
-/* validator-1 (global.css) */
+/* validator-1-start (global.css) */
 
 .page {
     padding: 20px;
@@ -12,6 +12,10 @@ exports[`allows to make CSS global: allows to make CSS global - CSS 1`] = `
 ._global_title {
     color: green;
 }
+
+/* validator-1-end (global.css) */
+
+/* validator-2-end (global.css) */
 "
 `;
 
@@ -22,7 +26,7 @@ Object {
 `;
 
 exports[`composes rules: composes rules - CSS 1`] = `
-"/* validator-2 (composes.css) *//* validator-1 (composes.a.css) */._composes_a_another-mixin {
+"/* validator-2-start (composes.css) *//* validator-1-start (composes.a.css) */._composes_a_another-mixin {
     display: -webkit-flex;
     display: -moz-box;
     display: flex;
@@ -30,7 +34,7 @@ exports[`composes rules: composes rules - CSS 1`] = `
     width: 200px;
 }._composes_a_hello {
     foo: bar;
-}/* validator-1 (composes.mixins.css) */._composes_mixins_title {
+}/* validator-1-end (composes.a.css) *//* validator-1-start (composes.mixins.css) */._composes_mixins_title {
     color: black;
     font-size: 40px;
 }._composes_mixins_title:hover {
@@ -40,9 +44,9 @@ exports[`composes rules: composes rules - CSS 1`] = `
 }._composes_mixins_title:focus, ._composes_mixins_figure:focus {
     outline: none;
     border: 1px solid red;
-}
+}/* validator-1-end (composes.mixins.css) */
 
-/* validator-1 (composes.css) */
+/* validator-1-start (composes.css) */
 
 .page {
     padding: 20px;
@@ -61,6 +65,10 @@ exports[`composes rules: composes rules - CSS 1`] = `
     display: -moz-box;
     display: flex;
 }
+
+/* validator-1-end (composes.css) */
+
+/* validator-2-end (composes.css) */
 "
 `;
 
@@ -89,9 +97,9 @@ Array [
 `;
 
 exports[`generates scoped name with interpolated string: generates scoped name with interpolated string - CSS 1`] = `
-"/* validator-2 (interpolated.css) */
+"/* validator-2-start (interpolated.css) */
 
-/* validator-1 (interpolated.css) */
+/* validator-1-start (interpolated.css) */
 
 .interpolated__title___2P3iB {
     color: green;
@@ -100,6 +108,10 @@ exports[`generates scoped name with interpolated string: generates scoped name w
 .interpolated__article___Skl0x {
     color: black;
 }
+
+/* validator-1-end (interpolated.css) */
+
+/* validator-2-end (interpolated.css) */
 "
 `;
 
@@ -111,8 +123,8 @@ Object {
 `;
 
 exports[`preserves comments: preserves comments - CSS 1`] = `
-"/* validator-2 (comments.css) */
-/* validator-1 (comments.css) */
+"/* validator-2-start (comments.css) */
+/* validator-1-start (comments.css) */
 /**
  * This is a doc comment...
  */
@@ -120,15 +132,17 @@ p {
   /* ...and a line comment */
   padding: 0;
 }
+/* validator-1-end (comments.css) */
+/* validator-2-end (comments.css) */
 "
 `;
 
 exports[`preserves comments: preserves comments - JSON 1`] = `Object {}`;
 
 exports[`processes classes: processes classes - CSS 1`] = `
-"/* validator-2 (classes.css) */
+"/* validator-2-start (classes.css) */
 
-/* validator-1 (classes.css) */
+/* validator-1-start (classes.css) */
 
 .page {
     padding: 20px;
@@ -141,6 +155,10 @@ exports[`processes classes: processes classes - CSS 1`] = `
 ._classes_article {
     color: black;
 }
+
+/* validator-1-end (classes.css) */
+
+/* validator-2-end (classes.css) */
 "
 `;
 
@@ -165,11 +183,9 @@ exports[`processes globalModulePaths option: processes globalModulePaths option 
 exports[`processes hashPrefix option: processes hashPrefix option 1`] = `"._8xPWf {}"`;
 
 exports[`processes values: processes values - CSS 1`] = `
-"/* validator-2 (values.css) */
+"/* validator-2-start (values.css) *//* validator-1-start (values.colors.css) *//* validator-1-end (values.colors.css) */
 
-/* validator-1 (values.colors.css) */
-
-/* validator-1 (values.css) */
+/* validator-1-start (values.css) */
 
 ._values_title {
     color: green;
@@ -178,6 +194,10 @@ exports[`processes values: processes values - CSS 1`] = `
 ._values_article {
     color: blue;
 }
+
+/* validator-1-end (values.css) */
+
+/* validator-2-end (values.css) */
 "
 `;
 
@@ -192,13 +212,13 @@ Object {
 `;
 
 exports[`saves origin plugins: saves origin plugins - CSS 1`] = `
-"/* validator-2 (plugins.css) *//* validator-1 (plugins.css) */
+"/* validator-2-start (plugins.css) *//* validator-1-start (plugins.css) */
 ._plugins_title {
     display: -webkit-flex;
     display: -moz-box;
     display: flex;
     color: green;
-}
+}/* validator-1-end (plugins.css) *//* validator-2-end (plugins.css) */
 "
 `;
 

--- a/test/test.js
+++ b/test/test.js
@@ -51,7 +51,8 @@ Object.keys(cases).forEach((name) => {
             throw new Error('Plugin before ours was called multiple times.')
           }
           rootsSeenBeforePlugin.add(root);
-          root.prepend(`/* validator-1 (${path.basename(root.source.input.file)}) */`);
+          root.prepend(`/* validator-1-start (${path.basename(root.source.input.file)}) */`);
+          root.append(`/* validator-1-end (${path.basename(root.source.input.file)}) */`);
         }
       ),
       plugin({
@@ -68,7 +69,8 @@ Object.keys(cases).forEach((name) => {
             throw new Error('Plugin after ours was called multiple times.')
           }
           rootsSeenAfterPlugin.add(root);
-          root.prepend(`/* validator-2 (${path.basename(root.source.input.file)}) */`);
+          root.prepend(`/* validator-2-start (${path.basename(root.source.input.file)}) */`);
+          root.append(`/* validator-2-end (${path.basename(root.source.input.file)}) */`);
         }
       ),
     ];

--- a/test/test.js
+++ b/test/test.js
@@ -51,7 +51,7 @@ Object.keys(cases).forEach((name) => {
             throw new Error('Plugin before ours was called multiple times.')
           }
           rootsSeenBeforePlugin.add(root);
-          root.prepend('/* validator-1 */');
+          root.prepend(`/* validator-1 (${path.basename(root.source.input.file)}) */`);
         }
       ),
       plugin({
@@ -68,7 +68,7 @@ Object.keys(cases).forEach((name) => {
             throw new Error('Plugin after ours was called multiple times.')
           }
           rootsSeenAfterPlugin.add(root);
-          root.prepend('/* validator-2 */');
+          root.prepend(`/* validator-2 (${path.basename(root.source.input.file)}) */`);
         }
       ),
     ];

--- a/test/test.js
+++ b/test/test.js
@@ -41,6 +41,12 @@ Object.keys(cases).forEach((name) => {
 
     const plugins = [
       autoprefixer,
+      postcss.plugin(
+        'test-comment-1',
+        () => (root) => {
+          root.prepend("/* this should also appear once in each file */");
+        }
+      ),
       plugin({
         scopeBehaviour,
         generateScopedName: scopedNameGenerator,
@@ -48,6 +54,12 @@ Object.keys(cases).forEach((name) => {
           resultJson = json;
         },
       }),
+      postcss.plugin(
+        'test-comment-2',
+        () => (root) => {
+          root.prepend("/* this should appear once in each file */");
+        }
+      )
     ];
 
     const result = await postcss(plugins).process(source, { from: sourceFile });


### PR DESCRIPTION
The input `css` has already been processed by any plugins before `postcss-module`, and the output will be processed by any plugins after. We shoud not run all the user plugins again.

However, for anything that is loaded in by the loader (such as from `composes`), we should run the plugins that were listed before `postcss-modules`, so that the css that is brought in can catch up.

Does this make sense? It fixes the problem for us.

Think this fixes https://github.com/css-modules/postcss-modules/issues/70