### PR TITLE
fix plugin order to loaders

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ module.exports = postcss.plugin(PLUGIN_NAME, (opts = {}) => {
       throw new Error('Plugin missing from options.');
     }
     const earlierPlugins = result.processor.plugins.slice(0, resultPluginIndex);
-    const loaderPlugins = [...pluginList, ...earlierPlugins];
+    const loaderPlugins = [...earlierPlugins, ...pluginList];
     const loader = getLoader(opts, loaderPlugins);
     const parser = new Parser(loader.fetch.bind(loader));
 


### PR DESCRIPTION
Just noticed that the user plugins should run before the others in the loader, in order for the order to be consistent with the order they load in the main build. This was a mistake in https://github.com/css-modules/postcss-modules/pull/111