### PR TITLE
test: check compatibility with PostCSS 8 visitor plugins

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -109,6 +109,26 @@ Object.keys(cases).forEach((name) => {
   });
 });
 
+it("works with visitor plugins", async () => {
+  const source = `
+p {
+  color: green;
+}
+`;
+
+  const plugins = [
+    {
+      postcssPlugin: "turn-values-blue",
+      Declaration(decl) {
+        decl.value = "blue";
+      },
+    },
+    plugin(),
+  ];
+  const result = await postcss(plugins).process(source, { from: undefined });
+  expect(result.css).toEqual(source.replace("green", "blue"));
+});
+
 it("saves JSON next to CSS by default", async () => {
   const sourceFile = path.join(fixturesPath, "in", "saveJSON.css");
   const source = fs.readFileSync(sourceFile).toString();


### PR DESCRIPTION
I've added a test that succeeds when postcss-modules uses `OnceExit()` and fails when it uses `Once()`, so we don't forget about the compatibility issue with visitor-based plugins.