### PR TITLE
WIP: Refactor loader dependencies

### DIFF
--- a/src/css-loader-core/loader.js
+++ b/src/css-loader-core/loader.js
@@ -1,112 +1,26 @@
-// Copied from https://github.com/css-modules/css-modules-loader-core
-
-import postcss from "postcss";
 import fs from "fs";
 import path from "path";
 
-import Parser from "./parser";
+export default (newPath, relativeTo, root) => {
+  return new Promise((resolve, reject) => {
+    let relativeDir = path.dirname(relativeTo),
+      absolutePath = path.resolve(
+        path.join(root, relativeDir),
+        newPath
+      );
 
-class Core {
-  constructor(plugins) {
-    this.plugins = plugins || Core.defaultPlugins;
-  }
-
-  load(sourceString, sourcePath, trace, pathFetcher) {
-    let parser = new Parser(pathFetcher, trace);
-
-    return postcss(this.plugins.concat([parser.plugin()]))
-      .process(sourceString, { from: "/" + sourcePath })
-      .then((result) => {
-        return {
-          injectableSource: result.css,
-          exportTokens: parser.exportTokens,
-        };
-      });
-  }
-}
-
-// Sorts dependencies in the following way:
-// AAA comes before AA and A
-// AB comes after AA and before A
-// All Bs come after all As
-// This ensures that the files are always returned in the following order:
-// - In the order they were required, except
-// - After all their dependencies
-const traceKeySorter = (a, b) => {
-  if (a.length < b.length) {
-    return a < b.substring(0, a.length) ? -1 : 1;
-  } else if (a.length > b.length) {
-    return a.substring(0, b.length) <= b ? -1 : 1;
-  } else {
-    return a < b ? -1 : 1;
-  }
-};
-
-export default class FileSystemLoader {
-  constructor(root, plugins) {
-    this.root = root;
-    this.sources = {};
-    this.traces = {};
-    this.importNr = 0;
-    this.core = new Core(plugins);
-    this.tokensByFile = {};
-  }
-
-  fetch(_newPath, relativeTo, _trace) {
-    let newPath = _newPath.replace(/^["']|["']$/g, ""),
-      trace = _trace || String.fromCharCode(this.importNr++);
-    return new Promise((resolve, reject) => {
-      let relativeDir = path.dirname(relativeTo),
-        rootRelativePath = path.resolve(relativeDir, newPath),
-        fileRelativePath = path.resolve(
-          path.join(this.root, relativeDir),
-          newPath
-        );
-
-      // if the path is not relative or absolute, try to resolve it in node_modules
-      if (newPath[0] !== "." && newPath[0] !== "/") {
-        try {
-          fileRelativePath = require.resolve(newPath);
-        } catch (e) {
-          // noop
-        }
+    // if the path is not relative or absolute, try to resolve it in node_modules
+    if (newPath[0] !== "." && newPath[0] !== "/") {
+      try {
+        absolutePath = require.resolve(newPath);
+      } catch (e) {
+        // noop
       }
+    }
 
-      const tokens = this.tokensByFile[fileRelativePath];
-      if (tokens) {
-        return resolve(tokens);
-      }
-
-      fs.readFile(fileRelativePath, "utf-8", (err, source) => {
-        if (err) reject(err);
-        this.core
-          .load(source, rootRelativePath, trace, this.fetch.bind(this))
-          .then(({ injectableSource, exportTokens }) => {
-            this.sources[fileRelativePath] = injectableSource;
-            this.traces[trace] = fileRelativePath;
-            this.tokensByFile[fileRelativePath] = exportTokens;
-            resolve(exportTokens);
-          }, reject);
-      });
+    fs.readFile(absolutePath, "utf-8", (err, source) => {
+      if (err) reject(err);
+      else resolve(source);
     });
-  }
-
-  get finalSource() {
-    const traces = this.traces;
-    const sources = this.sources;
-    let written = new Set();
-
-    return Object.keys(traces)
-      .sort(traceKeySorter)
-      .map((key) => {
-        const filename = traces[key];
-        if (written.has(filename)) {
-          return null;
-        }
-        written.add(filename);
-
-        return sources[filename];
-      })
-      .join("");
-  }
+  });
 }

--- a/src/css-loader-core/parser.js
+++ b/src/css-loader-core/parser.js
@@ -2,14 +2,22 @@
 
 const importRegexp = /^:import\((.+)\)$/;
 import replaceSymbols from "icss-replace-symbols";
+import postcss from 'postcss';
+import path from "path";
 
 export default class Parser {
-  constructor(pathFetcher, trace) {
+  constructor(root, plugins, pathFetcher, trace, ctx = {}) {
+    this.root = root;
+    this.plugins = plugins;
     this.pathFetcher = pathFetcher;
     this.plugin = this.plugin.bind(this);
     this.exportTokens = {};
     this.translations = {};
     this.trace = trace;
+
+    this.sources = ctx.sources || {};
+    this.traces = ctx.traces || {};
+    this.tokensByFile = ctx.tokensByFile || {};
   }
 
   plugin() {
@@ -65,16 +73,87 @@ export default class Parser {
   fetchImport(importNode, relativeTo, depNr) {
     let file = importNode.selector.match(importRegexp)[1],
       depTrace = this.trace + String.fromCharCode(depNr);
-    return this.pathFetcher(file, relativeTo, depTrace).then(
-      (exports) => {
-        importNode.each((decl) => {
-          if (decl.type == "decl") {
-            this.translations[decl.prop] = exports[decl.value];
-          }
-        });
-        importNode.remove();
-      },
-      (err) => console.log(err)
-    );
+    let newPath = file.replace(/^["']|["']$/g, "");
+    let relativeDir = path.dirname(relativeTo),
+      rootRelativePath = path.resolve(relativeDir, newPath),
+      fileRelativePath = path.resolve(
+        path.join(this.root, relativeDir),
+        newPath
+      );
+    let subParser = new Parser(this.root, this.plugins, this.pathFetcher, depTrace, {
+      sources: this.sources,
+      traces: this.traces,
+      tokensByFile: this.tokensByFile
+    })
+    const tokens = this.tokensByFile[fileRelativePath]
+
+    const base = tokens
+      ? Promise.resolve(tokens)
+      : this.pathFetcher(newPath, relativeTo, this.root)
+      .then(content => {
+        return postcss(this.plugins.concat([subParser.plugin()]))
+          .process(content, { from: "/" + rootRelativePath })
+          .then((result) => {
+            return {
+              injectableSource: result.css,
+              exportTokens: subParser.exportTokens,
+            };
+          })
+          .then(({ injectableSource, exportTokens }) => {
+            this.sources[fileRelativePath] = injectableSource;
+            this.traces[depTrace] = fileRelativePath;
+            this.tokensByFile[fileRelativePath] = exportTokens;
+            return exportTokens;
+          });
+      })
+    return base
+      .then(
+        (exports) => {
+          importNode.each((decl) => {
+            if (decl.type == "decl") {
+              this.translations[decl.prop] = exports[decl.value];
+            }
+          });
+          importNode.remove();
+        },
+        (err) => console.log(err)
+      );
+  }
+
+
+  get finalSource() {
+    const traces = this.traces;
+    const sources = this.sources;
+    let written = new Set();
+
+    return Object.keys(traces)
+      .sort(traceKeySorter)
+      .map((key) => {
+        const filename = traces[key];
+        if (written.has(filename)) {
+          return null;
+        }
+        written.add(filename);
+
+        return sources[filename];
+      })
+      .join("");
   }
 }
+
+// Sorts dependencies in the following way:
+// AAA comes before AA and A
+// AB comes after AA and before A
+// All Bs come after all As
+// This ensures that the files are always returned in the following order:
+// - In the order they were required, except
+// - After all their dependencies
+const traceKeySorter = (a, b) => {
+  if (a.length < b.length) {
+    return a < b.substring(0, a.length) ? -1 : 1;
+  } else if (a.length > b.length) {
+    return a.substring(0, b.length) <= b ? -1 : 1;
+  } else {
+    return a < b ? -1 : 1;
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import camelCase from "lodash.camelcase";
 import genericNames from "generic-names";
 
 import Parser from "./css-loader-core/parser";
-import FileSystemLoader from "./css-loader-core/loader";
+import defaultLoader from "./css-loader-core/loader";
 
 import generateScopedName from "./generateScopedName";
 import saveJSON from "./saveJSON";
@@ -29,11 +29,10 @@ function getScopedNameGenerator(opts) {
   });
 }
 
-function getLoader(opts, plugins) {
-  const root = typeof opts.root === "undefined" ? "/" : opts.root;
+function getLoader(opts) {
   return typeof opts.Loader === "function"
-    ? new opts.Loader(root, plugins)
-    : new FileSystemLoader(root, plugins);
+    ? opts.loader
+    : defaultLoader;
 }
 
 function isGlobalModule(globalModules, inputFile) {
@@ -84,14 +83,15 @@ module.exports = (opts = {}) => {
       }
       const earlierPlugins = result.processor.plugins.slice(0, resultPluginIndex);
       const loaderPlugins = [...earlierPlugins, ...pluginList];
-      const loader = getLoader(opts, loaderPlugins);
-      const parser = new Parser(loader.fetch.bind(loader));
+      const loader = getLoader(opts);
+      const root = typeof opts.root === "undefined" ? "/" : opts.root;
+      const parser = new Parser(root, loaderPlugins, loader);
 
       await postcss([...pluginList, parser.plugin()]).process(css, {
         from: inputFile,
       });
 
-      const out = loader.finalSource;
+      const out = parser.finalSource;
       if (out) css.prepend(out);
 
       if (opts.localsConvention) {


### PR DESCRIPTION
Closes #118
Very WIP, I still need to clean up the resulting mess.
However, the loader roughly looks like I wanted it to, so I wanted to get some early feedback.

I basically moved all the logic that wasn't about loading a file to the parser class, which eliminated the weird `Core` in-between altogether. As a result, the parser is now a mess, so that needs to be cleaned up still. 
Also, the parser still deals with absolute file paths, since I just pulled out the sources hash from the loader. That needs to be changed too, since a file might not necessarily come from disk as far as the parser is concerned.

TODOs:
- [ ] clean up code
- [ ] find new hashing structure for source chunks
- [ ] flatten out the nested parser instances; should be possible with just one instance